### PR TITLE
Fix typo in network in directory tree for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ GitOps driven homelab using ArgoCD with a flat repository structure.
 │   └── settings.json          # Project specific settings
 ├── docs/                      # Documentation
 │   ├── faq.md                 # Frequently Asked Questions
-│   ├── netowrk.md             # Networking details
+│   ├── network.md             # Networking details
 │   └── setup.md               # Installation steps
 ├── manifest/                  # Watched by ArgoCD ApplicationSet
 │   └── $namespace.yaml        # Per namespace, App of Apps


### PR DESCRIPTION
Fixes network being spelled incorrectly in directory tree in repo README